### PR TITLE
PWX-28222: Set PX_SECRETS_NAMESPACE env variable to point to portworx namespace

### DIFF
--- a/chart/portworx/templates/storage-cluster.yaml
+++ b/chart/portworx/templates/storage-cluster.yaml
@@ -136,15 +136,12 @@ spec:
   {{- if ne $secretType "none" }}
   secretsProvider: {{$secretType}}
   {{- end }}
+  {{- if or (or (or (or (not (eq $envVars "none")) (not (eq $etcdSecret "none"))) (eq $csiCloudDrive true)) (eq $icrRegistry true)) (ne $licenseSecret "none") }}
   env:
-  {{- $IS_PX_SECRETS_NAMESPACE_SET := false }}
   {{- if not (eq $envVars "none") }}
     {{- $vars := $envVars | split ";" }}
     {{- range $key, $val := $vars }}
     {{- $envVariable := $val | split "=" }}
-    {{- if eq $envVariable._0 "PX_SECRETS_NAMESPACE" }}
-      {{- $IS_PX_SECRETS_NAMESPACE_SET = true}}
-    {{- end }}
     - name: {{ $envVariable._0 | trim | quote }}
       value: {{ $envVariable._1 | trim | quote }}
     {{- end }}
@@ -176,9 +173,6 @@ spec:
           name: "{{ $licenseSecret }}"
           key: accountKey
   {{- end }}
-  {{- if eq $IS_PX_SECRETS_NAMESPACE_SET false}}
-    - name: "PX_SECRETS_NAMESPACE"
-      value: "portworx"
   {{- end }}
   stork:
     enabled: true

--- a/chart/portworx/templates/storage-cluster.yaml
+++ b/chart/portworx/templates/storage-cluster.yaml
@@ -25,6 +25,7 @@
   {{- $etcdSecret := .Values.etcd.secret | default "none" }}
   {{- $changePortRange := .Values.changePortRange | default false }}
   {{- $pvcControllerEnabled := .Values.enablePVCController | default false }}
+  {{- $pxSecretsNamespace := .Values.pxSecretsNamespace | default "portworx" }}
 
 kind: StorageCluster
 apiVersion: core.libopenstorage.org/v1
@@ -136,7 +137,6 @@ spec:
   {{- if ne $secretType "none" }}
   secretsProvider: {{$secretType}}
   {{- end }}
-  {{- if or (or (or (or (not (eq $envVars "none")) (not (eq $etcdSecret "none"))) (eq $csiCloudDrive true)) (eq $icrRegistry true)) (ne $licenseSecret "none") }}
   env:
   {{- if not (eq $envVars "none") }}
     {{- $vars := $envVars | split ";" }}
@@ -173,7 +173,8 @@ spec:
           name: "{{ $licenseSecret }}"
           key: accountKey
   {{- end }}
-  {{- end }}
+    - name: "PX_SECRETS_NAMESPACE"
+      value: "{{ $pxSecretsNamespace }}"
   stork:
     enabled: true
     {{- if .Values.storkVersion }}

--- a/chart/portworx/templates/storage-cluster.yaml
+++ b/chart/portworx/templates/storage-cluster.yaml
@@ -136,12 +136,15 @@ spec:
   {{- if ne $secretType "none" }}
   secretsProvider: {{$secretType}}
   {{- end }}
-  {{- if or (or (or (or (not (eq $envVars "none")) (not (eq $etcdSecret "none"))) (eq $csiCloudDrive true)) (eq $icrRegistry true)) (ne $licenseSecret "none") }}
   env:
+  {{- $IS_PX_SECRETS_NAMESPACE_SET := false }}
   {{- if not (eq $envVars "none") }}
     {{- $vars := $envVars | split ";" }}
     {{- range $key, $val := $vars }}
     {{- $envVariable := $val | split "=" }}
+    {{- if eq $envVariable._0 "PX_SECRETS_NAMESPACE" }}
+      {{- $IS_PX_SECRETS_NAMESPACE_SET = true}}
+    {{- end }}
     - name: {{ $envVariable._0 | trim | quote }}
       value: {{ $envVariable._1 | trim | quote }}
     {{- end }}
@@ -173,6 +176,9 @@ spec:
           name: "{{ $licenseSecret }}"
           key: accountKey
   {{- end }}
+  {{- if eq $IS_PX_SECRETS_NAMESPACE_SET false}}
+    - name: "PX_SECRETS_NAMESPACE"
+      value: "portworx"
   {{- end }}
   stork:
     enabled: true

--- a/chart/portworx/values.yaml
+++ b/chart/portworx/values.yaml
@@ -16,6 +16,7 @@ network:
   dataInterface: none                # Name of the interface <ethX>
   managementInterface: none          # Name of the interface <ethX>
 
+pxSecretsNamespace: portworx         # Defaults to portworx
 secretType: none                     # Defaults to None, but can be aws-kms/vault/k8s/kvdb/ibm-kp
 envVars: none                        # NOTE: This is a ";" seperated list of environment variables. For eg: MYENV1=myvalue1;MYENV2=myvalue2
 advOpts: none

--- a/chart/portworx/values.yaml
+++ b/chart/portworx/values.yaml
@@ -16,7 +16,7 @@ network:
   dataInterface: none                # Name of the interface <ethX>
   managementInterface: none          # Name of the interface <ethX>
 
-pxSecretsNamespace: portworx         # Defaults to portworx
+pxSecretsNamespace: portworx         # Defaults to portworx, it specifies the namespace in which you create the px secrets
 secretType: none                     # Defaults to None, but can be aws-kms/vault/k8s/kvdb/ibm-kp
 envVars: none                        # NOTE: This is a ";" seperated list of environment variables. For eg: MYENV1=myvalue1;MYENV2=myvalue2
 advOpts: none


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets PX_SECRETS_NAMESPACE env variable to portworx

**Which issue(s) this PR fixes** (optional)
Closes # PWX-28222

**Special notes for your reviewer**:
Testing:
- Created a cluster on ibm cloud with ibm helm chart
- Created a Secret px-ibm with namespace portworx and Keys
- Restarted storage cluster and set secretProvider to ibm-kp
- Created a encryped volume with 'pxctl create --secure volname'
- Attached volume to host and verified using 'pxctl volume list'
