### PR TITLE
PWX-45816: Use MIRRORS_SERVER URL for both ROKS and IKS

### DIFF
--- a/chart/portworx/templates/storage-cluster.yaml
+++ b/chart/portworx/templates/storage-cluster.yaml
@@ -185,6 +185,8 @@ spec:
   env:
     - name: KUBELET_DIR
       value: "/var/data/kubelet"
+    - name: MIRRORS_SERVER
+      value: https://px-mirror.storage.cloud.ibm.com
   {{- if not (eq $envVars "none") }}
     {{- $vars := $envVars | split ";" }}
     {{- range $key, $val := $vars }}
@@ -205,10 +207,6 @@ spec:
           key: "password"
           name: "{{ $etcdSecret }}"
   {{- end }}
-  {{- if eq true $isOCP }}
-    - name: MIRRORS_SERVER
-      value: https://px-mirror.storage.cloud.ibm.com
-  {{- end}}
   {{- if eq $csiCloudDrive true }}
     - name: ENABLE_CSI_DRIVE
       value: "{{ $csiCloudDrive }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
MIRRORS_SERVER URL should be added into StorageCluster CR for both IKS and ROKS

**Which issue(s) this PR fixes** (optional)
Closes PWX-45816 